### PR TITLE
Disregard alleged binder entities beyond parcel bounds

### DIFF
--- a/libs/binder/Parcel.cpp
+++ b/libs/binder/Parcel.cpp
@@ -411,7 +411,7 @@ status_t Parcel::appendFrom(const Parcel *parcel, size_t offset, size_t len)
     // Count objects in range
     for (int i = 0; i < (int) size; i++) {
         size_t off = objects[i];
-        if ((off >= offset) && (off < offset + len)) {
+        if ((off >= offset) && (off + sizeof(flat_binder_object) <= offset + len)) {
             if (firstIndex == -1) {
                 firstIndex = i;
             }


### PR DESCRIPTION
When appending one parcel's contents to another, ignore binder
objects within the source Parcel that appear to lie beyond the
formal bounds of that Parcel's data buffer.

Bug 17312693

Change-Id: If592a260f3fcd9a56fc160e7feb2c8b44c73f514
(cherry picked from commit 27182be9f20f4f5b48316666429f09b9ecc1f22e)
